### PR TITLE
Restructure docs navigation with grouped sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,19 @@ pnpm dev:all
 lazor-kit/
 ├── packages/
 │   ├── sdk/          # Core SDK package
-│   ├── portal/       # Passkey sharing hub 
-│   ├── program/      # Core smart contract framework for smart wallet 
+│   ├── portal/       # Passkey sharing hub
+│   ├── program/      # Core smart contract framework for smart wallet
 │   └── docs/         # Documentation
 └── package.json      # Root configuration
 ```
+
+## Repository layout
+
+Historically Lazor Kit has been managed as a PNPM workspace/monorepo. We are in
+the process of transitioning to a multi-repository model so each surface area
+(SDK, portal, on-chain program, documentation, examples) can evolve and release
+independently. See [REPO_STRUCTURE.md](./REPO_STRUCTURE.md) for the proposed
+split and migration checklist.
 
 ## Contributing
 

--- a/REPO_STRUCTURE.md
+++ b/REPO_STRUCTURE.md
@@ -1,0 +1,69 @@
+# Proposed Repository Structure (Multi-Repo Friendly)
+
+This document captures a suggested split of the current monorepo into a set of
+focused repositories. The intent is to make it easier to publish and iterate on
+each surface area independently while still allowing them to collaborate as a
+cohesive Lazor Kit project.
+
+## Goals
+
+- Reduce coupling between deliverables so that SDK, portal, on-chain program and
+documentation can evolve on their own cadence.
+- Clarify ownership, release cycle and dependency boundaries.
+- Keep local development productive by documenting how to pull the related
+repositories together when required.
+
+## Recommended Repositories
+
+| Repository | Purpose | Primary Tech | Notes |
+| --- | --- | --- | --- |
+| `lazor-wallet-sdk` | Browser & mobile SDK published to npm. | TypeScript, Zustand, Solana web3.js | Ships React hooks and smart-wallet client. Mirrors the current `packages/wallet` content. |
+| `lazor-portal` | Hosted passkey portal application that pairs with the SDK. | React 19, Vite, Tailwind | Provides the iframe/popup UI and WebAuthn messaging bridge. |
+| `lazor-program` | Anchor smart contract and generated IDL. | Rust, Anchor | Produces on-chain artifacts and TypeScript IDL clients. |
+| `lazor-docs` | Public documentation site. | Vocs | Hosts the docs currently under `packages/docs`. |
+| `lazor-examples` | Sample applications (React Native, web). | Expo, React Native | Aggregates example integrations currently under `example/`. |
+
+Each repository would become independent with its own `package.json` (where
+applicable), build scripts and release pipeline.
+
+## Cross-Repository Contracts
+
+1. **IDL & Type Definitions**: `lazor-program` exports the generated IDL package
+   (`idl/` + TypeScript types). `lazor-wallet-sdk` depends on published versions
+   instead of sibling imports.
+2. **Portal Messaging**: Shared message schemas are published from the SDK repo
+   (or a dedicated `lazor-shared` package) and imported by the portal to avoid
+drift.
+3. **Documentation**: `lazor-docs` consumes published packages (SDK, portal) as
+   dependencies when generating API references; it should not reach into source
+   of other repositories directly.
+4. **Examples**: Example apps depend on released npm packages (`lazor-wallet-sdk`,
+   `@lazorkit/portal`) and tagged program IDs.
+
+## Development Workflow
+
+- Use a meta-repo or `pnpm workspaces` only for local convenience when needing
+  to work on multiple pieces simultaneously. Document how to clone the related
+  repositories side-by-side and use `pnpm link` or `npm link` as needed.
+- Provide Docker Compose or task runner scripts in `lazor-examples` to spin up
+the portal locally while pointing to a local SDK build.
+
+## Migration Steps
+
+1. Extract each package into its own Git repository, preserving history with
+   `git filter-repo` or `git subtree split`.
+2. Trim the root `package.json` so it only contains shared tooling (linting,
+   formatting) or remove it once each repo is standalone.
+3. Update CI pipelines per repository (build, lint, test, release).
+4. Publish new npm packages scoped appropriately (`@lazorkit/*`).
+5. Update documentation and README links to point to the new repositories.
+
+## Open Questions
+
+- Should we keep a lightweight meta repo that aggregates all repos via Git
+  submodules for onboarding convenience?
+- How do we version shared message schemas across SDK and portal—dedicated
+  package or rely on semver compatibility guarantees?
+
+Documenting these decisions early will make the transition smoother for future
+contributors and maintainers.

--- a/packages/docs/docs/pages/concepts/architecture.mdx
+++ b/packages/docs/docs/pages/concepts/architecture.mdx
@@ -1,0 +1,44 @@
+# Architecture Overview
+
+Understand how the LazorKit project is split across multiple packages and services, and how they interact in a production deployment.
+
+## Component Breakdown
+
+LazorKit is delivered as a collection of focused packages that can live in separate repositories:
+
+- **Web SDK (`@lazorkit/wallet`)** – A React-first client SDK that exposes hooks, providers, and a smart-wallet controller for browser applications.
+- **Portal Web App (`@lazorkit/portal`)** – A passkey-ready popup/iframe experience that performs WebAuthn registration, signing, and secure messaging with the SDK.
+- **On-chain Program (`@lazorkit/program`)** – Anchor-based Solana program code that runs the smart wallet logic and verifies passkey signatures on-chain.
+- **Documentation (`@lazorkit/docs`)** – This site, which documents how to use and operate the other packages.
+
+## Runtime Flow
+
+```mermaid
+sequenceDiagram
+    participant App as Your App
+    participant SDK as LazorKit SDK
+    participant Portal as Passkey Portal
+    participant Program as Solana Program
+
+    App->>SDK: Request authentication / transaction
+    SDK->>Portal: Open passkey window via postMessage
+    Portal->>App: Passkey approval result
+    SDK->>Program: Submit signed instructions
+    Program->>App: Emit transaction status
+```
+
+1. **Your application** invokes SDK helpers to trigger login, create wallets, or send transactions.
+2. **The SDK** acts as the orchestrator, opening the portal when biometric or hardware passkeys are required and maintaining the smart-wallet session locally.
+3. **The Portal** handles WebAuthn UX in an isolated surface and relays signed payloads back to the SDK.
+4. **The Program** receives the signed payload and executes it on Solana, emitting events back to the SDK to update UI state.
+
+## Repository Boundaries
+
+When splitting LazorKit into multiple repositories, keep the contracts between packages explicit:
+
+- The SDK consumes the Portal as a published asset (e.g., CDN build) and communicates via a versioned postMessage protocol.
+- The SDK and Portal share TypeScript interface packages for message payloads and event schemas.
+- The Program exposes generated IDL artifacts that are imported by the SDK for instruction builders.
+- Documentation tracks the published versions of each package and links to their dedicated repositories.
+
+Keeping these seams well documented ensures contributors can work on a single package without needing the entire workspace.

--- a/packages/docs/docs/pages/guides/integration.mdx
+++ b/packages/docs/docs/pages/guides/integration.mdx
@@ -1,4 +1,4 @@
-# Integration Guide
+# Web Integration Guide
 
 This guide covers advanced integration patterns and best practices for LazorKit SDK.
 

--- a/packages/docs/docs/pages/guides/transactions.mdx
+++ b/packages/docs/docs/pages/guides/transactions.mdx
@@ -1,4 +1,4 @@
-# Transaction Handling
+# Transaction Lifecycle
 
 Comprehensive guide to handling Solana transactions with LazorKit's smart wallet system.
 

--- a/packages/docs/vocs.config.ts
+++ b/packages/docs/vocs.config.ts
@@ -5,19 +5,59 @@ export default defineConfig({
   description: 'Seamless Web3 authentication for the web with passkey integration',
   sidebar: [
     {
-      text: 'Introduction',
-      link: '/',
+      text: 'Overview',
+      collapsed: false,
+      items: [
+        {
+          text: 'Introduction',
+          link: '/',
+        },
+        {
+          text: 'Architecture Overview',
+          link: '/concepts/architecture',
+        },
+      ],
     },
     {
-      text: 'Getting Started',
-      link: '/getting-started',
+      text: 'Quickstart',
+      collapsed: false,
+      items: [
+        {
+          text: 'Getting Started',
+          link: '/getting-started',
+        },
+        {
+          text: 'Installation',
+          link: '/installation',
+        },
+      ],
     },
     {
-      text: 'Installation',
-      link: '/installation',
+      text: 'Core Concepts',
+      collapsed: false,
+      items: [
+        {
+          text: 'Authentication Flow',
+          link: '/guides/authentication',
+        },
+        {
+          text: 'Transaction Lifecycle',
+          link: '/guides/transactions',
+        },
+      ],
     },
     {
-      text: 'API Reference',
+      text: 'How-to Guides',
+      collapsed: false,
+      items: [
+        {
+          text: 'Web Integration',
+          link: '/guides/integration',
+        },
+      ],
+    },
+    {
+      text: 'SDK Reference',
       collapsed: false,
       items: [
         {
@@ -31,24 +71,6 @@ export default defineConfig({
         {
           text: 'Types',
           link: '/api/types',
-        },
-      ],
-    },
-    {
-      text: 'Guides',
-      collapsed: false,
-      items: [
-        {
-          text: 'Integration Guide',
-          link: '/guides/integration',
-        },
-        {
-          text: 'Authentication Flow',
-          link: '/guides/authentication',
-        },
-        {
-          text: 'Transaction Handling',
-          link: '/guides/transactions',
         },
       ],
     },


### PR DESCRIPTION
## Summary
- reorganize the documentation sidebar into overview, quickstart, concepts, guides, and SDK reference sections
- add an architecture overview concept page describing the multi-package runtime flow and repository boundaries
- retitle existing guides to match the new navigation labels

## Testing
- not run (documentation-only change)

------